### PR TITLE
Converted adeptsense to editing for apidoc

### DIFF
--- a/vi_mode.lua
+++ b/vi_mode.lua
@@ -1013,7 +1013,7 @@ mode_command = {
     },
     
     -- Show help
-    f1 = textadept.adeptsense.show_apidoc,
+    f1 = textadept.editing.show_documentation,
 
     -- Misc: suspend the editor
     cz = M.kill.kill,


### PR DESCRIPTION
Since 7.3 adeptsense has been deprecated and expunged, the new format
is by using the textadept.editing method. Anyway, here's a quick fix
to help your vi implementation work with >=7.3 versions of textadept.
