### PR TITLE
tests: Allow location overrides for textadept and tail

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,12 +1,14 @@
 STRACE :=
 TMUX_EXTRA :=
 
+TA ?= ../../textadept-curses
 ifeq ($(DEBUG),1)
 STRACE := strace -s4096 -o output/ta.strace
 TMUX_EXTRA :=  \; attach
+TA := $(STRACE) $(TA)
 endif
-TA := $(STRACE) ../../textadept-curses
 TMUX := tmux -f userhome/tmux.conf
+TAIL ?= tail
 
 # tmux configuration
 TMUX_SOCKET := ./output/tmux-socket
@@ -23,13 +25,14 @@ clean:
 	rm -r output
 
 test: output
+	@if [ ! -f ./userhome/modules/textredux/buffer_list.lua ]; then echo "Textredux must exist at ./userhome/modules/textredux"; exit 1; fi
 	@# Remove previous output file to avoid confusion.
 	@rm -f output/results.txt output/sem.fifo
 	@touch output/results.txt
 	@mkfifo output/sem.fifo
 	$(TMUX) -S $(TMUX_SOCKET) -C new-session -d $(TMUX_SIZE) "TESTS=\"$(TESTS)\" bash " \; send-keys "$(TA) --nosession --userhome ./userhome " \; send-keys enter $(TMUX_EXTRA)
 	@echo Waiting for test...
-	@head -1 output/sem.fifo >/dev/null & tail --pid=$$! --follow=name output/results.txt
+	@head -1 output/sem.fifo >/dev/null & $(TAIL) --pid=$$! --follow=name output/results.txt
 	@grep FAIL output/results.txt && exit 1 || exit 0
   
 # Convenience target to attach to any session still running.


### PR DESCRIPTION
All tests pass on my NetBSD box. I have to override a couple locations/binary names though.
e.g.

    $ PATH="/usr/pkg/bin:$PATH" gmake TA=/home/eric/apps/textadept-fcb8982b4599/textadept-curses TAIL=gtail